### PR TITLE
注释了;application.baseUri = '' ;not used

### DIFF
--- a/application/conf/app.ini
+++ b/application/conf/app.ini
@@ -11,7 +11,7 @@ application.view.ext = "html"
 
 ;app 配置
 application.dispatcher.catchException=1 
-application.baseUri = '' ;not used
+;application.baseUri = '' ;not used
 ;application.dispatcher.defaultModule = index
 application.dispatcher.defaultController = index
 application.dispatcher.defaultAction = index


### PR DESCRIPTION
引起Yaf_Controller not found error.
